### PR TITLE
Ajout trois associations

### DIFF
--- a/web/registre-assos-vélo.yaml
+++ b/web/registre-assos-vélo.yaml
@@ -50,8 +50,8 @@
   diminutif: AVB
   région: Bourgogne-Franche-Comté
   métropole: Grand Besançon Métropole
-  logo: https://asso.velobesancon.info/logo_avb1/
-  site: https://asso.velobesancon.info/
+  logo: https://imgur.com/kWbW1JH.jpg
+  site: https://asso.velobesancon.info
   adhésion: https://asso.velobesancon.info/contact/
   twitter: VeloBesancon
   facebook: AssociationVeloBesancon
@@ -68,7 +68,8 @@
   diminutif: SAV
   région: Grand-Est
   métropole: Eurométropole de Strasbourg
-  site: https://www.strasbourgavelo.org/
+  site: https://www.strasbourgavelo.org
+  logo: https://imgur.com/X0VKdpL.jpg
   adhésion: https://www.strasbourgavelo.org/association/
   twitter: strasbourgavelo
   mastodon: "@SAV@masto.bike"

--- a/web/registre-assos-vélo.yaml
+++ b/web/registre-assos-vélo.yaml
@@ -71,5 +71,5 @@
   site: https://www.strasbourgavelo.org/
   adhésion: https://www.strasbourgavelo.org/association/
   twitter: strasbourgavelo
-  mastodon: @SAV@masto.bike
+  mastodon: "@SAV@masto.bike"
   facebook: strasbourgavelo

--- a/web/registre-assos-vélo.yaml
+++ b/web/registre-assos-vélo.yaml
@@ -67,7 +67,7 @@
 - nom: Strasbourg À Vélo
   diminutif: SAV
   région: Grand-Est
-  métropole: Eurométropole de Strasbourg
+  métropole: Strasbourg Eurométropole
   site: https://www.strasbourgavelo.org
   logo: https://imgur.com/X0VKdpL.jpg
   adhésion: https://www.strasbourgavelo.org/association/

--- a/web/registre-assos-vélo.yaml
+++ b/web/registre-assos-vélo.yaml
@@ -45,3 +45,31 @@
   twitter: Velocite63
   mastodon: velocite63@pouet.chapril.org
   facebook: velocite63
+
+- nom: Association Vélo Besançon
+  diminutif: AVB
+  région: Bourgogne-Franche-Comté
+  métropole: Grand Besançon Métropole
+  logo: https://asso.velobesancon.info/logo_avb1/
+  site: https://asso.velobesancon.info/
+  adhésion: https://asso.velobesancon.info/contact/
+  twitter: VeloBesancon
+  facebook: AssociationVeloBesancon
+  
+- nom: Selle Vous Plait
+  diminutif: SVP
+  région: Bourgogne-Franche-Comté
+  métropole: Communauté de communes du Grand Pontarlier
+  logo: https://static.wixstatic.com/media/ce908a_6d01a01cf28540d180d52dd83c09faf8~mv2.png/v1/fill/w_475,h_336,al_c,q_85,usm_0.66_1.00_0.01,enc_auto/logo-sellevousplait.png
+  site: https://sellevousplait.wixsite.com/home
+  adhésion: https://sellevousplait.wixsite.com/home/devenir-membre
+
+- nom: Strasbourg À Vélo
+  diminutif: SAV
+  région: Grand-Est
+  métropole: Eurométropole de Strasbourg
+  site: https://www.strasbourgavelo.org/
+  adhésion: https://www.strasbourgavelo.org/association/
+  twitter: strasbourgavelo
+  mastodon: @SAV@masto.bike
+  facebook: strasbourgavelo


### PR DESCRIPTION
On laisse comme tel ou faut ranger par ordre alphabétique ?

Quitte à se baser sur Wikipédia je pense qu'on pourrait carrément passer par un identifiant Wikidata